### PR TITLE
Update docs and scripts to use main branch.

### DIFF
--- a/bud/get.bash
+++ b/bud/get.bash
@@ -1,1 +1,1 @@
-nix flake new -t "github:divnix/devos/master" "${2:-devos}"
+nix flake new -t "github:divnix/devos/main" "${2:-devos}"

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Pull Requests
 
 ## TL;DR;
-- **Target Branch**: `master`
+- **Target Branch**: `main`
 - **Merge Policy**: [`bors`][bors] is always right (&rarr; `bors try`)
 - **Docs**: every changeset is expected to contain doc updates
 - **Commit Msg**: be a poet! Comprehensive and explanatory commit messages 

--- a/doc/concepts/profiles.md
+++ b/doc/concepts/profiles.md
@@ -63,5 +63,5 @@ specific belongs in your [host](hosts.md) files instead.
 [definition]: https://nixos.org/manual/nixos/stable/index.html#sec-option-definitions
 [declaration]: https://nixos.org/manual/nixos/stable/index.html#sec-option-declarations
 [options]: https://nixos.org/manual/nixos/stable/index.html#sec-writing-modules
-[spec]: https://github.com/divnix/devos/tree/master/lib/devos/mkProfileAttrs.nix
+[spec]: https://github.com/divnix/devos/tree/main/lib/devos/mkProfileAttrs.nix
 [config]: https://nixos.wiki/wiki/Module#structure

--- a/doc/concepts/users.md
+++ b/doc/concepts/users.md
@@ -73,5 +73,5 @@ nix build "github:divnix/devos#homeConfigurations.nixos@NixOS.home.activationPac
 ```
 
 [home-manager]: https://nix-community.github.io/home-manager
-[modules-list]: https://github.com/divnix/devos/tree/master/users/modules/module-list.nix
+[modules-list]: https://github.com/divnix/devos/tree/main/users/modules/module-list.nix
 [portableuser]: https://digga.divnix.com/api-reference-home.html#homeusers

--- a/doc/integrations/nvfetcher.md
+++ b/doc/integrations/nvfetcher.md
@@ -40,4 +40,4 @@ fetch.git = "https://github.com/mlvzk/manix.git" # responsible for fetching
 
 [nvf]: https://github.com/berberman/nvfetcher
 [nvf-readme]: https://github.com/berberman/nvfetcher#readme
-[sources.toml]: https://github.com/divnix/devos/tree/master/pkgs/sources.toml
+[sources.toml]: https://github.com/divnix/devos/tree/main/pkgs/sources.toml

--- a/doc/start/index.md
+++ b/doc/start/index.md
@@ -6,8 +6,8 @@ Here is a snippet that will get you the template without the git history:
 ```sh
 nix-shell -p cachix --run "cachix use nrdxp"
 
-nix-shell https://github.com/divnix/devos/archive/master.tar.gz -A shell \
-  --run "bud get master"
+nix-shell https://github.com/divnix/devos/archive/main.tar.gz -A shell \
+  --run "bud get main"
 
 cd devos
 

--- a/doc/tests.md
+++ b/doc/tests.md
@@ -26,7 +26,7 @@ and the examples in [nixpkgs][nixos-tests].
 
 [test-doc]: https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests
 [test-blog]: https://www.haskellforall.com/2020/11/how-to-use-nixos-for-lightweight.html
-[default]: https://github.com/divnix/devos/tree/master/tests/default.nix
+[default]: https://github.com/divnix/devos/tree/main/tests/default.nix
 [run-test]: https://github.com/NixOS/nixpkgs/blob/6571462647d7316aff8b8597ecdf5922547bf365/lib/debug.nix#L154-L166
 [nixos-tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
 [testing-python]: https://github.com/NixOS/nixpkgs/tree/master/nixos/lib/testing-python.nix


### PR DESCRIPTION
When following the getting started guide commands were failing due to
the mater branch not existing. I went through and updated all
references in the docs and other scripts from master to main.